### PR TITLE
TTK-20960 info: Using the 'geant_track' instead of the 'display'

### DIFF
--- a/Resources/views/MultimediaObject/info.html.twig
+++ b/Resources/views/MultimediaObject/info.html.twig
@@ -49,7 +49,7 @@
   </div>
 </div>
 {# START DEBUG LINK #}
-{% set url = multimediaObject.getTrackWithTag('display').getUrl()|default(false) %}
+{% set url = multimediaObject.getTrackWithTag('geant_track').getUrl()|default(false) %}
 {% if url %}
   <div class="row">
     <div class="col-xs-12">


### PR DESCRIPTION
This is because some mmobjs don't have displayable tracks, but they still have 'iframe' tracks